### PR TITLE
fix: upgrade PHPUnit to ^8.5.52 to address CVE-2026-24765

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -3,49 +3,61 @@ name: "PHPUnit tests"
 on:
   pull_request:
   push:
+    branches:
+      - master
+      - main
 
 jobs:
   phpunit:
-    name: "PHPUnit tests (PHP v${{ matrix.php-version }})"
-
-    runs-on: ${{ matrix.operating-system }}
+    name: "PHPUnit (PHP ${{ matrix.php-version }}) - ${{ matrix.dependencies }}"
+    runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         php-version:
-          - "7.0"
-          - "7.1"
           - "7.2"
           - "7.3"
-#          - "7.4"
-#          - "8.0"
-        operating-system:
-          - "ubuntu-18.04"
+          - "7.4"
+          - "8.0"
+          - "8.1"
+          - "8.2"
+          - "8.3"
+          - "8.4"
+        dependencies:
+          - "lowest"
+          - "highest"
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v4"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          coverage: "pcov"
           php-version: "${{ matrix.php-version }}"
-          ini-values: memory_limit=-1
-          tools: composer:v2, cs2pr
-          extensions: mbstring, dom, zip, phalcon3
+          coverage: "none"
+          tools: composer:v2
+          extensions: mbstring, dom, zip, phalcon
+
+      - name: "Get composer cache directory"
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: "Cache dependencies"
-        uses: "actions/cache@v2"
+        uses: "actions/cache@v4"
         with:
-          path: |
-            ~/.composer/cache
-            vendor
-          key: "php-${{ matrix.php-version }}"
-          restore-keys: "php-${{ matrix.php-version }}"
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-${{ matrix.dependencies }}-
 
-      - name: "Test with lowest dependencies"
-        run: "composer update --prefer-lowest --no-interaction --no-progress --no-suggest && vendor/bin/phpunit"
+      - name: "Install lowest dependencies"
+        if: matrix.dependencies == 'lowest'
+        run: "composer update --prefer-lowest --no-interaction --no-progress --prefer-dist"
 
-      - name: "Test with highest dependencies"
-        run: "composer update --no-interaction --no-progress --no-suggest && vendor/bin/phpunit"
+      - name: "Install highest dependencies"
+        if: matrix.dependencies == 'highest'
+        run: "composer update --no-interaction --no-progress --prefer-dist"
+
+      - name: "Run tests"
+        run: "./vendor/bin/phpunit"

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ gen
 
 /vendor/
 /composer.lock
+.phpunit.result.cache
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+PHP_VERSIONS = 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4
+TEST_TARGETS = $(addprefix test-,$(PHP_VERSIONS))
+
+.PHONY: help test $(TEST_TARGETS)
+
+help:
+	@echo "Usage: make <target>"
+	@echo ""
+	@echo "Targets:"
+	@echo "  test             Run tests on all supported PHP versions"
+	@echo "  test-<version>   Run tests on a specific PHP version (e.g., make test-8.1)"
+	@echo ""
+	@echo "Supported versions: $(PHP_VERSIONS)"
+
+test: $(TEST_TARGETS)
+
+$(TEST_TARGETS): test-%:
+	@echo ">>> Running tests on PHP $*"
+	docker run --rm -v $(CURDIR):/app -w /app mileschou/phalcon:$*-cli \
+		sh -c "echo 'deb http://archive.debian.org/debian buster main' > /etc/apt/sources.list && \
+		echo 'deb http://archive.debian.org/debian-security buster/updates main' >> /etc/apt/sources.list || true && \
+		apt-get update -o Acquire::Check-Valid-Until=false && \
+		apt-get install -y curl git unzip && \
+		curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
+		composer update --no-interaction && \
+		./vendor/bin/phpunit"

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Command pattern implementation in PHP, for the 'Undo' functionality.",
   "type": "library",
   "require-dev": {
-    "phpunit/phpunit": "^6.5 || ^7.5",
+    "phpunit/phpunit": "^8.5.52 || ^9.0",
     "psalm/phar": "^3.2 || ^4.7"
   },
   "license": "MIT",
@@ -15,8 +15,8 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "php": "^7.0 || ^8.0",
-    "ext-phalcon": "^3.0"
+    "php": "^7.2 || ^8.0",
+    "ext-phalcon": "^3.0 || ^4.0"
   },
   "autoload": {
     "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "minimum-stability": "stable",
   "require": {
     "php": "^7.2 || ^8.0",
-    "ext-phalcon": "^3.0 || ^4.0"
+    "ext-phalcon": "^3.0 || ^4.0 || ^5.0"
   },
   "autoload": {
     "classmap": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/sebastianbergmann/phpunit/master/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
          colors="true"
          verbose="true"
-         cacheDirectory=".phpunit.cache"
          failOnRisky="true"
          failOnWarning="true">
     <testsuites>
@@ -13,9 +12,9 @@
         </testsuite>
     </testsuites>
 
-    <coverage ignoreDeprecatedCodeUnits="true">
-        <include>
+    <filter>
+        <whitelist>
             <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/unit/AbstractCommandTest.php
+++ b/tests/unit/AbstractCommandTest.php
@@ -10,7 +10,7 @@ class AbstractCommandTest extends TestCase
     private $parameters;
     private $command;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->parameters = [
             'old' => 'state',


### PR DESCRIPTION
- Upgraded phpunit/phpunit to ^8.5.52 || ^9.0.
- Bumped minimum PHP version to ^7.2.
- Updated ext-phalcon requirement to ^3.0 || ^4.0 || ^5.0.
- Migrated phpunit.xml to PHPUnit 8 format.
- Updated tests for PHPUnit 8 compatibility (setUp return type).
- Added Makefile for local Docker-based testing.
- Updated GitHub Actions to test PHP 7.2-8.4 with lowest/highest deps.